### PR TITLE
ブショーダスライト補助ツール

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | - | - |
 | [bro3_Auto_Bilder](bro3_Auto_Bilder) | 通称ビルダー。自動内政（建築/削除）、武器防具強化、造兵、糧変換など |
 | [bro3_auto_daily_quest](bro3_auto_daily_quest) | 繰り返しクエストのクエクリ補助 |
+| [bro3_busyodas](bro3_busyodas) | ブショーダスライト補助 |
 | [bro3_calc_defense](bro3_calc_defense) | 出兵時に民兵出現予測を表示 |
 | [bro3_display_skill](bro3_display_skill) | デッキ画面で武将のスキルを表示。ブショーダス画面、トレード画面、合成画面、カード削除画面に対応。合成画面ではスキル付与確率表示にも対応。 |
 | [bro3_donate_window](bro3_donate_window) | 同盟タブで寄付をしやすくする。残す量や寄付後の合計値を確認しながら寄付したり、一括寄付に対応。 |

--- a/bro3_busyodas/bro3_busyodas.user.js
+++ b/bro3_busyodas/bro3_busyodas.user.js
@@ -1,0 +1,56 @@
+// ==UserScript==
+// @name		bro3_busyodas
+// @namespace	https://gist.github.com/RAPT21/
+// @description	ブラウザ三国志 ブショーダスライト補助 by RAPT
+// @include		https://*.3gokushi.jp/busyodas/busyodas_continuty_result.php*
+// @include		http://*.3gokushi.jp/busyodas/busyodas_continuty_result.php*
+// @require		https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js
+// @connect		3gokushi.jp
+// @grant		none
+// @author		RAPT
+// @version 	0.1
+// ==/UserScript==
+jQuery.noConflict();
+q$ = jQuery;
+
+var VERSION = "2020.11.11.dev";
+
+// ブショーダスライト画面で下記スキル名にマッチしないカードに削除チェックを入れるツール。
+// スキル名は部分一致。
+// デフォルトでロックされているR以上のカードや特殊カードは変更しない。
+
+// 部分一致
+var wantSkillNames = [
+	"仁君",
+	"呉の治世",
+	"守護防陣",
+	"忠節不落",
+//	"兵舎修練",
+//	"英雄",
+//	"兵器の猛撃",
+//	"修練",
+//	"急速援護",
+//	"火神の攻勢",
+	"全軍の"
+];
+
+function isWantSkill(skillName) {
+	var result = false;
+	q$.each(wantSkillNames, function(index, name){
+		var re = new RegExp(`${name}.*LV.+`);
+		if (re.test(skillName)) {
+			result = true;
+			return false;
+		}
+	});
+	return result;
+}
+
+q$("#busyodasDraw_18110500000 .commonTables tr").each(function(){
+	var cols = q$("td", this);
+	if (cols.length === 4) {
+		if (!isWantSkill(cols.eq(2).text().trim())) {
+			q$("input.delete", cols.eq(0)).prop('checked', true);
+		}
+	}
+});


### PR DESCRIPTION
ブショーダスライトで「ブショーダスを10回引く」ボタンを押したとき、
不要なカードについて、自動で削除チェックを入れるツール。

単純な機能ながら、BP 消化時に仁君カードなどを誤って削除しないようにする。

※今のところ1枚引きには未対応。
※引くのは手動。削除も手動。あくまでチェックを入れるだけ。