### PR TITLE
[beyond] 地形1.0 対応（一部）

### DIFF
--- a/bro3_beyond/bro3_beyond.user.js
+++ b/bro3_beyond/bro3_beyond.user.js
@@ -4,7 +4,7 @@
 // @include		https://*.3gokushi.jp/*
 // @include		http://*.3gokushi.jp/*
 // @description	ブラウザ三国志beyondリメイク by Craford 氏 with RAPT
-// @version		1.09.30
+// @version		1.09.31
 // @updateURL	http://craford.sweet.coocan.jp/content/tool/beyond/bro3_beyond.user.js
 
 // @grant	GM_addStyle
@@ -124,6 +124,9 @@
 // 1.09.30	2023/06/27	RAPT. 「領地一覧：領地LVUP時のアラートを抑制」を追加
 //						- 「同盟トップ：同盟員全領地座標CSV取得」機能が動作しなくなっていたのを修正
 //						- 「同盟トップ：同盟員本拠座標取得」機能が動作しなくなっていたのを修正
+// 1.09.31	2023/07/25	RAPT. 「共通：地形1.0」を追加
+//						- メニューの一部を地形1.0対応
+//						- 地形1.0マップで「Profile：NPC隣接同盟探索」が動作するよう暫定対処
 
 
 //----------------------------------------------------------------------

--- a/bro3_beyond/bro3_beyond.user.js
+++ b/bro3_beyond/bro3_beyond.user.js
@@ -1107,17 +1107,17 @@ function profileControl() {
 				y1 = sw;
 			}
 
-			if (x1 < -1200) {
-				x1 = -1200;
+			if (x1 < -1300) {
+				x1 = -1300;
 			}
-			if (x2 > 1200) {
-				x2 = 1200;
+			if (x2 > 1300) {
+				x2 = 1300;
 			}
-			if (y1 < -1200) {
-				y1 = -1200;
+			if (y1 < -1300) {
+				y1 = -1300;
 			}
-			if (y2 > 1200) {
-				y2 = 1200;
+			if (y2 > 1300) {
+				y2 = 1300;
 			}
 
 			var sizex = Math.abs(x2 - x1) + 1 - 10 * 2;
@@ -1472,8 +1472,7 @@ function profileControl() {
 					//-------------
 					// NPC隣接探索
 					//-------------
-					if (q$("#search_event_npc").prop('checked') == false) {
-						// search_pattern = new RegExp("rewrite\\('(.*)', '(.*)', '.*', '(.*)', '(.*)', '([★]*)', '.*', '.*', '.*', '.*', '.*', '.*', '.*'\\); overOpe");
+					if (q$("#search_event_npc").prop('checked') == false) {// 削除中、(地名)、(君主名)、人口、(座標)、(同盟名)、(戦力)、距離、森岩鉄糧、NPCフラグ、保護期間、深夜停戦
 						search_pattern = new RegExp("rewriteAddRemoving\\('.*','(.*)', '(.*)', '.*', '(.*)', '(.*)', '([★]*)', '.*', '.*', '.*', '.*', '.*', '.*', '.*', .*\\); overOpe");
 					} else {
 						search_pattern = new RegExp("rewritePF\\(.*,'(.*)', '(.*)', '.*', '(.*)', '(.*)', '([★]*) '.*', '.*', '.*', '.*', '.*', '.*', '.*'\\); overOpe");
@@ -1505,7 +1504,11 @@ function profileControl() {
 					var result_box = q$("#result_npc_box");
 
 					var list = new Array();
-					list.push("NPC名\tX座標\tY座標\t★\t所有同盟\t北西\t北\t北東\t西\t東\t南西\t南\t南東");
+					if (g_beyond_options[COMMON_04]) {
+						list.push("NPC名\tX座標\tY座標\t★\t所有盟主\t北西\t北\t北東\t西\t東\t南西\t南\t南東");
+					} else {
+						list.push("NPC名\tX座標\tY座標\t★\t所有同盟\t北西\t北\t北東\t西\t東\t南西\t南\t南東");
+					}
 					var listcnt = 0;
 					var count = 1;
 					var max = search_target.length;
@@ -1528,9 +1531,11 @@ function profileControl() {
 
 						wait = true;
 
-						var loc = {'x':search_target[count-1].x, 'y':search_target[count-1].y, 'type':1};
+						var map_type = g_beyond_options[COMMON_04] ? 4 : 1;
+						var map_path = g_beyond_options[COMMON_04] ? '/big_map.php' : '/map.php';
+						var loc = {'x':search_target[count-1].x, 'y':search_target[count-1].y, 'type':map_type};
 						q$.ajax({
-							url: BASE_URL + '/map.php',
+							url: BASE_URL + map_path,
 							type: 'GET',
 							datatype: 'html',
 							cache: false,
@@ -1538,32 +1543,108 @@ function profileControl() {
 						})
 						.done(function(res) {
 							var resp = q$("<div>").append(res);
-							var area = q$("#mapOverlayMap area", resp);
+							var area = g_beyond_options[COMMON_04] ? q$("#map51-content.map-v2 li a[onmouseover]", resp) : q$("#mapOverlayMap area[onmouseover]", resp);
 
 							// NPC隣接調査
-							var check = [60, 48, 59, 70, 49, 71, 50, 61, 72];
+							function checkMapCellList() {
+								var map_size = g_beyond_options[COMMON_04] ? 51 : 11;
+								// 配列の順は 対象NPC砦、北西、北、北東、西、東、南西、南、南東
+								var idx_center = (map_size + 1) * ((map_size - 1) / 2);
+								var list = [idx_center];
+								if (map_size === 11) {
+									// 斜めMAPの場合、最西から北→南で並ぶ; center = 60
+									list.push(idx_center - map_size - 1);
+									list.push(idx_center - 1);
+									list.push(idx_center + map_size - 1);
+									list.push(idx_center - map_size);
+									list.push(idx_center + map_size);
+									list.push(idx_center - map_size + 1);
+									list.push(idx_center + 1);
+									list.push(idx_center + map_size + 1);
+								} else if (map_size === 51) {
+									// 51MAPの場合、最北から西→東で並ぶ; center = 1300
+									list.push(idx_center - map_size - 1);
+									list.push(idx_center - map_size);
+									list.push(idx_center - map_size + 1);
+									list.push(idx_center - 1);
+									list.push(idx_center + 1);
+									list.push(idx_center + map_size - 1);
+									list.push(idx_center + map_size);
+									list.push(idx_center + map_size + 1);
+								} else {
+									console.log("不明なMAPです。");
+								}
+								return list;
+							}
+
+							var check = checkMapCellList();
 							var tsv = "";
 							var neighbor = "";
 							for (var i = 0; i < check.length; i++) {
 								// 一致検索
-								var match = q$(area[check[i]]).attr("onmouseover").match(search_pattern);
-								if (match == null) {
-									continue;
-								}
-								if (match[4] == '') {
-									match[4] = '-';
-								}
-
-								if (i == 0) {
-									// NPC名、座標、★数、所有同盟
-									var pos = match[3].match(/([-]*\d+),([-]*\d+)/);
-									tsv += match[1] + "\t" + parseInt(pos[1]) + "\t" + parseInt(pos[2]) + "\t★" + match[5].length + "\t" + match[4];
-								} else {
-									// 隣接（北西、北、北東、西、東、南西、南、南東の順）。所持同盟がいない場合'-'
-									if (match[4] != '-') {
-										tsv += match[4];
+								var attr_onmouseover = q$(area[check[i]]).attr("onmouseover");
+								if (g_beyond_options[COMMON_04]) {
+									var axis = attr_onmouseover.match(new RegExp('距離</dt><dd>\\(([-]?\\d+),([-]?\\d+)\\)'));
+									if (axis == null) {
+										continue;
+									}
+									// NPC砦では同盟名が取得できないので取得できなくてもエラーにしない
+									var ally_name = attr_onmouseover.match(new RegExp('<dt>同盟名</dt><dd>(.*?)</dd>'));
+									ally_name = (ally_name == null) ? '-' : ally_name[1];
+									if (i == 0) {
+										var npc_name = attr_onmouseover.match(new RegExp('<dt class=\"bigmap-caption\">(.*?)</dt>'));
+										if (npc_name == null) {
+											continue;
+										} else {
+											npc_name = npc_name[1];
+										}
+										var owner_name = attr_onmouseover.match(new RegExp('<dt>君主名</dt><dd>(.*?)</dd>'));
+										if (owner_name == null) {
+											continue;
+										} else {
+											owner_name = owner_name[1];
+										}
+										var star = attr_onmouseover.match(new RegExp('<span class="npc-red-star">([★]+).*?</span>'));
+										if (star == null) {
+											continue;
+										} else {
+											star = star[1].length;
+										}
+										// NPC砦名と守衛名が一致する場合は未攻略砦とし、所有君主名'-'
+										var ma = npc_name.match(/^(.*?)砦(\d+)$/);
+										var mo = owner_name.match(/^(.*?)守衛(\d+)$/);
+										if (ma != null && mo != null && ma[1] == mo[1] && ma[2] == mo[2]) {
+											owner_name = '-';
+										}
+										tsv += npc_name + "\t" + parseInt(axis[1]) + "\t" + parseInt(axis[2]) + "\t★" + star + "\t" + owner_name;
 									} else {
-										tsv += "-";
+										// 隣接（北西、北、北東、西、東、南西、南、南東の順）。所持同盟がいない場合'-'
+										if (ally_name != '-') {
+											tsv += ally_name;
+										} else {
+											tsv += "-";
+										}
+									}
+								} else {
+									var match = attr_onmouseover.match(search_pattern);
+									if (match == null) {
+										continue;
+									}
+									if (match[4] == '') {
+										match[4] = '-';
+									}
+
+									if (i == 0) {
+										// NPC名、座標、★数、所有同盟
+										var pos = match[3].match(/([-]*\d+),([-]*\d+)/);
+										tsv += match[1] + "\t" + parseInt(pos[1]) + "\t" + parseInt(pos[2]) + "\t★" + match[5].length + "\t" + match[4];
+									} else {
+										// 隣接（北西、北、北東、西、東、南西、南、南東の順）。所持同盟がいない場合'-'
+										if (match[4] != '-') {
+											tsv += match[4];
+										} else {
+											tsv += "-";
+										}
 									}
 								}
 								if (i != 8) {
@@ -1592,7 +1673,7 @@ function profileControl() {
 							wait = false;
 						});
 					};
-					npc_timer = setInterval(neighbor_search_func, 150);
+					npc_timer = setInterval(neighbor_search_func, 1000);
 				}
 			}
 		);

--- a/bro3_beyond/bro3_beyond.user.js
+++ b/bro3_beyond/bro3_beyond.user.js
@@ -3887,6 +3887,8 @@ function execCommonPart() {
 
 		var loc = q$("li.gnavi02 a").attr('href');
 		var bigloc = loc.replace('/map.php?', '/big_map.php?');
+		var eleloc = loc.replace('/map.php?', '/elevation_map.php?');
+		var _3dloc = loc.replace('/map.php?', '/3d_map.php?');
 
 		var cur_x = 0;
 		var cur_y = 0;
@@ -3894,6 +3896,50 @@ function execCommonPart() {
 		if (match) {
 			cur_x = match[1];
 			cur_y = match[2];
+		}
+
+		var mapmenu;
+		if (g_beyond_options[COMMON_04]) {
+			mapmenu = [
+				['21x21', eleloc + '&map_size=21'], ['41x41', eleloc + '&map_size=41'], ['3D', _3dloc], ['旧51x51', bigloc + '&type=4'],
+			];
+		} else {
+			mapmenu = [
+				['11x11', loc + '&type=1'], ['21x21', loc + '&type=5'], ['51x51', loc + '&type=4'], ['スクロール21x21', bigloc + '&type=6&ssize=21'], ['スクロール51x51', bigloc + '&type=6&ssize=51'],
+			];
+		}
+
+		var allymenu;
+		if (g_beyond_options[COMMON_04]) {
+			allymenu = [
+				['連結状況', alurl + '/rampart_tower_group.php'],
+				['友軍状況', alurl + '/friendly_army.php'],
+				['遷都状況', alurl + '/castle_transfer.php'],
+				['同盟ログ', alurl + '/alliance_log.php',
+					[
+						['全て', alogurl], ['攻撃', alogurl + '?m=attack'], ['防御', alogurl + '?m=defense'], ['偵察', alogurl + '?m=scout'],
+						['破壊', alogurl + '?m=fall'], ['援軍', alogurl + '?m=reinforcement'], ['友軍', alogurl + '?m=friendly_army'], ['同盟', alogurl + '?m=alliance'],
+					],
+				],
+				['ランキング', alurl + '/ranking.php'], ['勢力リスト', alurl + '/dependency.php'], ['同盟掲示板', BASE_URL + '/bbs/topic_view.php'],
+				['同盟スキル', alurl + '/alliance_skill.php'],
+				['管理', alurl + '/manage.php'],
+				['配下同盟管理', alurl + '/manage_dep.php'],
+			];
+		} else {
+			allymenu = [
+				['友軍状況', alurl + '/friendly_army.php'],
+				['同盟ログ', alurl + '/alliance_log.php',
+					[
+						['全て', alogurl], ['攻撃', alogurl + '?m=attack'], ['防御', alogurl + '?m=defense'], ['偵察', alogurl + '?m=scout'],
+						['破壊', alogurl + '?m=fall'], ['援軍', alogurl + '?m=reinforcement'], ['友軍', alogurl + '?m=friendly_army'], ['同盟', alogurl + '?m=alliance'],
+					],
+				],
+				['ランキング', alurl + '/ranking.php'], ['勢力リスト', alurl + '/dependency.php'], ['同盟掲示板', BASE_URL + '/bbs/topic_view.php'],
+				['同盟スキル', alurl + '/alliance_skill.php'],
+				['管理', alurl + '/manage.php'],
+				['配下同盟管理', alurl + '/manage_dep.php'],
+			];
 		}
 
 		var menus = [
@@ -3927,23 +3973,9 @@ function execCommonPart() {
 				],
 			],
 			// 全体地図
-			[
-				['11x11', loc + '&type=1'], ['21x21', loc + '&type=5'], ['51x51', loc + '&type=4'], ['スクロール21x21', bigloc + '&type=6&ssize=21'], ['スクロール51x51', bigloc + '&type=6&ssize=51'],
-			],
+			mapmenu,
 			// 同盟
-			[
-				['友軍状況', alurl + '/friendly_army.php'],
-				['同盟ログ', BASE_URL + '/alliance/alliance_log.php',
-					[
-						['全て', alogurl], ['攻撃', alogurl + '?m=attack'], ['防御', alogurl + '?m=defense'], ['偵察', alogurl + '?m=scout'],
-						['破壊', alogurl + '?m=fall'], ['援軍', alogurl + '?m=reinforcement'], ['友軍', alogurl + '?m=friendly_army'], ['同盟', alogurl + '?m=alliance'],
-					],
-				],
-				['ランキング', alurl + '/ranking.php'], ['勢力リスト', alurl + '/dependency.php'], ['同盟掲示板', BASE_URL + '/bbs/topic_view.php'],
-				['同盟スキル', alurl + '/alliance_skill.php'],
-				['管理', alurl + '/manage.php'],
-				['配下同盟管理', alurl + '/manage_dep.php'],
-			],
+			allymenu,
 			// デッキ
 			[
 				['城トップ', facurl + '/castle.php'],
@@ -4002,6 +4034,7 @@ function execCommonPart() {
 								['名声獲得', BASE_URL + '/council/arms.php?council_function_id=207'],
 							],
 						],
+						['城壁塔', BASE_URL + '/council/?tab=7'], // 地形1.0マップのみだが階層が深いのでこのままにしておく
 						['農村', BASE_URL + '/council/?tab=3'],
 						['設計', BASE_URL + '/council/?tab=4'],
 						['南蛮', BASE_URL + '/council/?tab=5'],

--- a/bro3_beyond/bro3_beyond.user.js
+++ b/bro3_beyond/bro3_beyond.user.js
@@ -228,6 +228,7 @@ var AJAX_REQUEST_INTERVAL = 100; // (ms)
 var COMMON_01 = 'co01';		// 資源タイマー
 var COMMON_02 = 'co02';		// プルダウンメニューを差し替える
 var COMMON_03 = 'co03';		// 天気予告常時表示
+var COMMON_04 = 'co04';		// 地形1.0
 
 // プロフィールタブ
 var PROFILE_01 = 'pr01';	// ランキングリンク追加
@@ -6007,6 +6008,7 @@ function draw_setting_window(append_target) {
 					<div><input type='checkbox' id='" + COMMON_01 + "'><label for='" + COMMON_01 + "'>資源タイマーを追加</label></input></div> \
 					<div><input type='checkbox' id='" + COMMON_02 + "'><label for='" + COMMON_02 + "'>プルダウンメニューを差し替える</label></input></div> \
 					<div><input type='checkbox' id='" + COMMON_03 + "'><label for='" + COMMON_03 + "'>天気バー上に天気予告を常時表示する</label></input></div> \
+					<div><input type='checkbox' id='" + COMMON_04 + "'><label for='" + COMMON_04 + "'>地形1.0</label></input></div> \
 				</div> \
 				<div id='tab-profile'> \
 					<div><input type='checkbox' id='" + PROFILE_01 + "'><label for='" + PROFILE_01 + "'>ランキングへのリンクを追加</label></input></div> \
@@ -10111,6 +10113,7 @@ function getDefaultOptions() {
 	settings[COMMON_01] = true;		// 資源タイマー
 	settings[COMMON_02] = true;		// プルダウンメニューを差し替える
 	settings[COMMON_03] = true; 	// 天気予告常時表示
+	settings[COMMON_04] = (["w7","w11","w20","w24","w28","w32"].indexOf(SERVER_NAME) < 0);	// 地形1.0 (公開時点で未対応鯖は初期値false、それ以外はtrue)
 
 	// プロフィール
 	settings[PROFILE_01] = true;	// ランキングのリンク追加


### PR DESCRIPTION
## 新機能
- オプションに「共通：地形1.0」を追加
  - 本PR作成時点で未導入のサーバーではデフォルト Off です。それ以外は On になります。

## 変更
- メニューの一部を地形1.0対応
  - 全体地図、同盟、軍議所を変更
  - ※軍議所→城壁塔の項目については地形1.0未対応マップでも表示されます
- 地形1.0マップで「Profile：NPC隣接同盟探索」が動作するよう暫定対処
  - NPC砦の所有同盟名が取得できなくなったため、代わりに所有盟主名を取得するように
