### PR TITLE
[beyond] デッキ：ファイル内スキル検索機能を追加で、1枠目にパッシブスキルがあると検出スキルがずれることがある問題に対処

### DIFF
--- a/bro3_beyond/bro3_beyond.user.js
+++ b/bro3_beyond/bro3_beyond.user.js
@@ -4,7 +4,7 @@
 // @include		https://*.3gokushi.jp/*
 // @include		http://*.3gokushi.jp/*
 // @description	ブラウザ三国志beyondリメイク by Craford 氏 with RAPT
-// @version		1.09.47
+// @version		1.09.48
 // @updateURL	http://craford.sweet.coocan.jp/content/tool/beyond/bro3_beyond.user.js
 
 // @grant	GM_addStyle
@@ -151,6 +151,7 @@
 // 1.09.46	2026/02/22	RAPT. 地図：一斉出兵で「兵士をつけて出兵」に鋭兵も含めるように
 //						- 地図：一斉出兵で「HP100未満を選択」を追加
 // 1.09.47	2026/04/12	RAPT. 即時落札ボタンのサイズを少し大きくした
+// 1.09.48	2026/05/15	RAPT. デッキ：ファイル内スキル検索機能を追加で、1枠目にパッシブスキルがあると検出スキルがずれることがある問題に対処
 
 
 //----------------------------------------------------------------------
@@ -6791,6 +6792,7 @@ function deck_resttime_checker() {
 								var skill = q$("b", info2).eq(j).text().replace(/[ \t]/g, "");
 								// 副将スキルは外す (2023/05/26 by pla2999)
 								if (/^副/.test(skill)) continue;
+								if (/^:/.test(skill)) continue; // 1枠目がパッシブだと表記がずれることがある運営バグ回避
 								if (skill === "\u00A0") continue; // スキル欄が空欄ならスキップ
 								skill = skill.replace(/^.*:/, "");
 								var skill_info = getSkillInfo(skill, q$('div.set a.control__button--deck-set-small', cards.eq(i)).attr('href'));


### PR DESCRIPTION
## 変更
- `デッキ：ファイル内スキル検索機能を追加`で、1枠目にパッシブスキルがあると検出スキルがずれることがある問題に対処
  - 原因は運営の表示バグ
  - 1枠目がパッシブで、3枠目にアクティブスキルがあるとバグる？

### スクショ
曹真| beforfe | after
--|--|--
<img width="184" height="45" alt="image" src="https://github.com/user-attachments/assets/86733d7d-5fae-45b3-9274-24a86ebd54cb" /> | <img width="454" height="214" alt="image" src="https://github.com/user-attachments/assets/c184fd3c-07ed-42e6-bb37-d1adaf7987ef" /> | <img width="420" height="192" alt="image" src="https://github.com/user-attachments/assets/d4d4efd3-49d4-4903-887f-693a0f2182c9" />



### 参考
通常 | 通常 | 表示バグ
--|--|--
パッシブ+アクティブ: OK | 全部アクティブ: OK | 「:」で始まる表示バグあり
<img width="273" height="376" alt="image" src="https://github.com/user-attachments/assets/5e8f74fa-88d5-46f1-a3bf-d0f7dee9f802" /> | <img width="284" height="381" alt="image" src="https://github.com/user-attachments/assets/b7343703-a4fa-49e8-8c68-c267b7b875a1" /> | <img width="278" height="451" alt="image" src="https://github.com/user-attachments/assets/2c614e3c-4f9d-43d2-b255-0bc139a174f8" />



## LINK
[bro3_beyond.user.js](https://github.com/RAPT21/bro3-tools/blob/master/bro3_beyond/bro3_beyond.user.js)